### PR TITLE
16 use openaire refresh token to grab a personal token for every run

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -127,6 +127,7 @@ dependencies:
       - pyparsing==3.0.9
       - pyrsistent==0.19.3
       - python-dateutil==2.8.2
+      - python-dotenv==1.0.1
       - python-json-logger==2.0.7
       - pytz==2022.7.1
       - pyyaml==6.0

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,16 @@ The package is not yet deployed to PyPI. Only an editable (development) install 
 2. Clone the repository `git clonehttps://github.com/ClimateCompatibleGrowth/research_index_backend.git`
 2. Change directory `cd research_index_backend`
 2. Install the package `pip install -e .` as an editable package (development install)
-3. Obtain an OpenAIRE Graph token or a refresh token and set as an environment variable
-
-        $ export TOKEN=<paste token here>
-        $ export REFRESH_TOKEN=<paste token here>
+3. Obtain an OpenAIRE Graph refresh token and create a .env file with the following parameters: 
+   ```MG_HOST=
+      MG_PORT=
+      MG_PORT_ALT=
+      ORCID_NAME_SIMILARITY_THRESHOLD=
+      NAME_SIMILARITY_THRESHOLD=
+      OPENAIRE_API="https://api.openaire.eu"
+      OPENAIRE_SERVICE="https://services.openaire.eu"
+      REFRESH_TOKEN=
+   ```
 
 4. Provision Memgraph graph database and set up environment variables
 
@@ -17,11 +23,6 @@ The package is not yet deployed to PyPI. Only an editable (development) install 
 
         $ curl -O https://download.memgraph.com/memgraph/v2.14.1/ubuntu-20.04/memgraph_2.14.1-1_amd64.deb
         $ sudo dpkg -i /memgraph_2.14.1-1_amd64.deb
-
-   Then setup environment variables on the local machine to point to the memgraph VM
-
-        $ export MG_HOST=127.168.0.1
-        $ export MG_PORT=7687
 
 5. Run the backend:
 

--- a/src/research_index_backend/config.py
+++ b/src/research_index_backend/config.py
@@ -1,0 +1,63 @@
+import logging
+import os
+
+import requests
+from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
+
+
+class Config:
+    def __init__(self):
+        load_dotenv()
+
+        self.mg_host: str = os.getenv("MG_HOST",)
+        self.mg_port: int = int(os.getenv("MG_PORT"))
+        self.mg_port_alt: int = int(os.getenv("MG_PORT_ALT"))
+
+        self.orcid_name_similarity_threshold: float = float(
+            os.getenv("ORCID_NAME_SIMILARITY_THRESHOLD")
+        )
+        self.name_similarity_threshold: float = float(
+            os.getenv("NAME_SIMILARITY_THRESHOLD")
+        )
+
+        self.openaire_api: str = os.getenv(
+            "OPENAIRE_API", "https://api.openaire.eu"
+        )
+        self.openaire_service: str = os.getenv(
+            "OPENAIRE_SERVICE", "https://services.openaire.eu"
+        )
+
+        self.openaire_token_endpoint = f"{self.openaire_service}/uoa-user-management/api/users/getAccessToken"
+        self.refresh_token: str = os.getenv("REFRESH_TOKEN")
+        self.token = self._get_personal_token()
+
+        self._validate()
+
+    def _validate(self):
+        if not 0 <= self.orcid_name_similarity_threshold <= 1:
+            raise ValueError(
+                "ORCID_NAME_SIMILARITY_THRESHOLD must be between 0 and 1"
+            )
+        if not 0 <= self.name_similarity_threshold <= 1:
+            raise ValueError(
+                "NAME_SIMILARITY_THRESHOLD must be between 0 and 1"
+            )
+
+    def _get_personal_token(self) -> str:
+        """Get personal token by providing a refresh token"""
+        if refresh_token := os.getenv("REFRESH_TOKEN"):
+            logger.info("Found refresh token. Obtaining personal token.")
+            query = f"?refreshToken={refresh_token}"
+            response = requests.get(self.openaire_token_endpoint + query)
+            logger.info(f"Status code: {response.status_code}")
+            logger.debug(response.json())
+            return response.json()["access_token"]
+        else:
+            raise ValueError(
+                "No refresh token found, could not obtain personal token"
+            )
+
+
+config = Config()

--- a/src/research_index_backend/get_metadata.py
+++ b/src/research_index_backend/get_metadata.py
@@ -19,11 +19,9 @@ basicConfig(
     level=DEBUG,
 )
 
-TOKEN = environ.get("TOKEN")
-
 
 def get_metadata_from_openaire(
-    session: requests_cache.CachedSession, doi: str
+    session: requests_cache.CachedSession, doi: str, token
 ):
     """Gets metadata from OpenAire
 
@@ -36,7 +34,7 @@ def get_metadata_from_openaire(
     -------
     """
     query = f"?format=json&doi={doi}"
-    headers = {"Authorization": f"Bearer {TOKEN}"}
+    headers = {"Authorization": f"Bearer {token}"}
     api_url = f"{OPENAIRE_API}/search/researchProducts"
 
     response = session.get(api_url + query, headers=headers)


### PR DESCRIPTION
Temporary solution for obtaining the OpenAIRE personal token. This process should eventually transition to using service authentication. Additionally, some tests that are currently failing must be fixed before merging into the main branch.