### PR TITLE
Fix tests

### DIFF
--- a/src/research_index_backend/config.py
+++ b/src/research_index_backend/config.py
@@ -33,7 +33,7 @@ class Config:
 
         self.openaire_token_endpoint = f"{self.openaire_service}/uoa-user-management/api/users/getAccessToken"
         self._refresh_token: str = ""
-        self._token = None
+        self._token: str = ""
         self._validate()
 
     @property

--- a/src/research_index_backend/config.py
+++ b/src/research_index_backend/config.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 class Config:
     def __init__(self):
         load_dotenv()
-        
+
         self.mg_host: str = os.getenv("MG_HOST", "127.0.0.1")
         self.mg_port: int = int(os.getenv("MG_PORT", 7687))
         self.mg_port_alt: int = int(os.getenv("MG_PORT_ALT", 7444))
@@ -32,14 +32,22 @@ class Config:
         )
 
         self.openaire_token_endpoint = f"{self.openaire_service}/uoa-user-management/api/users/getAccessToken"
-        self._validate()
+        self.refresh_token: str = ""
+        self.token = None
 
-    @property
-    def refresh_token(self):
-        return os.getenv("REFRESH_TOKEN")
-    @property
-    def token(self):
-        return self._get_personal_token()
+        @property
+        def refresh_token(self):
+            return os.getenv("REFRESH_TOKEN", None)
+
+        @property
+        def token(self):
+            if self.token:
+                return self.token
+            else:
+                self.token = self._get_personal_token()
+                return self.token
+
+        self._validate()
 
     def _validate(self):
         if not 0 <= self.orcid_name_similarity_threshold <= 1:
@@ -65,11 +73,12 @@ class Config:
             except requests.JSONDecodeError as e:
                 logger.error(f"Error decoding JSON response: {e}")
                 raise ValueError(
-                    "Failed to obtain personal token due to JSON decode error. Check if the refresh token is correct or has not expired."
+                    "Failed to obtain personal token due to JSON decode error"
                 )
         else:
             raise ValueError(
                 "No refresh token found, could not obtain personal token"
             )
+
 
 config = Config()

--- a/src/research_index_backend/config.py
+++ b/src/research_index_backend/config.py
@@ -32,22 +32,28 @@ class Config:
         )
 
         self.openaire_token_endpoint = f"{self.openaire_service}/uoa-user-management/api/users/getAccessToken"
-        self.refresh_token: str = ""
-        self.token = None
-
-        @property
-        def refresh_token(self):
-            return os.getenv("REFRESH_TOKEN", None)
-
-        @property
-        def token(self):
-            if self.token:
-                return self.token
-            else:
-                self.token = self._get_personal_token()
-                return self.token
-
+        self._refresh_token: str = ""
+        self._token = None
         self._validate()
+
+    @property
+    def refresh_token(self):
+        if self._refresh_token:
+            return self._refresh_token
+        else:
+            self._refresh_token = os.getenv("REFRESH_TOKEN", None)
+            if self._refresh_token:
+                return self._refresh_token
+            else:
+                raise ValueError("No refresh token provided")
+
+    @property
+    def token(self):
+        if self._token:
+            return self._token
+        else:
+            self._token = self._get_personal_token()
+            return self._token
 
     def _validate(self):
         if not 0 <= self.orcid_name_similarity_threshold <= 1:


### PR DESCRIPTION
Problem - tests would not run due to config failing if no REFRESH_TOKEN defined.

- Changed `config.token` and `config.refresh_token` to properties so that token is only obtained once (and then stored) and properties are only accessed on demand.  These allows the tests to run as the token does not fail as the module is loaded (e.g. when running the tests).
- Linting and whitespace