### PR TITLE
Fix DOI ingestion bugs

### DIFF
--- a/src/research_index_backend/doi.py
+++ b/src/research_index_backend/doi.py
@@ -194,7 +194,7 @@ class DOIManager:
     def validate_dois(self, db: Driver) -> Dict[str, DOI]:
         try:
             self.pattern_check()
-            self.search_dois(db)
+            self.search_dois()
             return self.doi_tracker
         except Exception as e:
             logger.error(f"DOI validation failed: {e}")

--- a/src/research_index_backend/doi.py
+++ b/src/research_index_backend/doi.py
@@ -190,8 +190,7 @@ class DOIManager:
             + "{self.num_new_dois} new DOIs"
         )
 
-    @connect_to_db
-    def validate_dois(self, db: Driver) -> Dict[str, DOI]:
+    def validate_dois(self) -> Dict[str, DOI]:
         try:
             self.pattern_check()
             self.search_dois()

--- a/src/research_index_backend/parser.py
+++ b/src/research_index_backend/parser.py
@@ -21,8 +21,8 @@ def parse_author(metadata: Dict) -> AnonymousAuthor | None:
         if pid and pid["id"]["scheme"] in ["orcid", "orcid_pending"]:
             orcid = pid["id"]["value"]
 
-    first_name = metadata.get("name", "").title()
-    last_name = metadata.get("surname", "").title()
+    first_name = (metadata.get("name") or "").title()
+    last_name = (metadata.get("surname") or "").title()
     if first_name in last_name:
         last_name = last_name.replace(first_name, "").strip()
     if last_name in first_name:


### PR DESCRIPTION
## Summary
- Fix `AttributeError` when OpenAIRE API returns `None` for author name/surname fields
- Fix `TypeError` from double `db` injection when calling `search_dois()` from `validate_dois()`

## Problem
When processing longer DOI lists, two bugs prevented successful ingestion:

1. **parser.py**: The OpenAIRE API can return `{"name": None}` for authors. Using `.get("name", "")` only provides a default when the key is missing, not when the value is `None`, causing `AttributeError: 'NoneType' object has no attribute 'title'`.

2. **doi.py**: Both `validate_dois()` and `search_dois()` are decorated with `@connect_to_db`. Calling `self.search_dois(db)` passed `db` explicitly while the decorator also injected it, causing `TypeError: search_dois() takes 2 positional arguments but 3 were given`.

## Fix
1. Changed `metadata.get("name", "")` to `(metadata.get("name") or "")` to handle `None` values
2. Changed `self.search_dois(db)` to `self.search_dois()` since the decorator handles `db` injection

## Test plan
- [x] Tested with longer DOI list (`list_of_doi.csv` from CCG) that previously failed.