### PR TITLE
Fix null publisher and None author crashes during DOI ingestion

### DIFF
--- a/src/research_index_backend/parser.py
+++ b/src/research_index_backend/parser.py
@@ -112,7 +112,7 @@ def parse_metadata(
 
         title = clean_html(entity["mainTitle"])
 
-        publisher = entity.get("publisher", None)
+        publisher = entity.get("publisher") or ""
 
         journal_meta = entity.get("journal", "")
         if journal_meta:
@@ -137,7 +137,7 @@ def parse_metadata(
                 author = parse_author(x)
                 if author:
                     all_authors.append(author)
-        else:
+        elif authors is not None:
             author = parse_author(authors)
             if author:
                 all_authors.append(author)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -176,6 +176,36 @@ class TestResearchProduct:
         expected = (2021, 5, 13)
         assert actual == expected
 
+    def test_parse_metadata_null_publisher(self):
+        """publisher: null in OpenAire response should produce publisher=''"""
+        file_path = os.path.join(
+            "tests", "fixtures", "openaire_v2_simple.json"
+        )
+
+        with open(file_path, "r") as json_file:
+            json = load(json_file)
+            json["results"][0]["publisher"] = None
+
+            actual = parse_metadata(json, "10.5281/zenodo.4650794", {})
+
+            assert len(actual) == 1
+            assert actual[0].publisher == ""
+
+    def test_parse_metadata_null_authors(self):
+        """authors: null in OpenAire response should produce an empty authors list"""
+        file_path = os.path.join(
+            "tests", "fixtures", "openaire_v2_simple.json"
+        )
+
+        with open(file_path, "r") as json_file:
+            json = load(json_file)
+            json["results"][0]["authors"] = None
+
+            actual = parse_metadata(json, "10.5281/zenodo.4650794", {})
+
+            assert len(actual) == 1
+            assert actual[0].authors == []
+
     def test_parse_metadata_openaire_v2(self):
 
         file_path = os.path.join(


### PR DESCRIPTION
- Handle `None` publisher from OpenAire metadata by falling back to an empty string, preventing a Pydantic validation error
- Skip `parse_author` when the authors field is `None` to prevent an `AttributeError` during metadata parsing